### PR TITLE
chore: update build images

### DIFF
--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -127,6 +127,8 @@ Resources:
 
           phases:
             install:
+              runtime-versions:
+                nodejs: 12.x
               commands:
                 - echo Install started on `date`
                 - chmod -R 755 ${BuildScriptsDir}/*
@@ -154,7 +156,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/nodejs:10.1.0
+        Image: aws/codebuild/standard:4.0
         EnvironmentVariables:
           - Name: AWS_DEFAULT_REGION
             Value: !Ref AWS::Region
@@ -306,6 +308,9 @@ Resources:
           version: 0.2
 
           phases:
+            install:
+              runtime-versions:
+                nodejs: 12.x
             pre_build:
               commands:
                 - aws s3 rm s3://$DEST_BUCKET --recursive
@@ -318,7 +323,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/ubuntu-base:14.04
+        Image: aws/codebuild/standard:4.0
         EnvironmentVariables:
           - Name: DEST_BUCKET
             Value:
@@ -343,6 +348,9 @@ Resources:
           version: 0.2
 
           phases:
+            install:
+              runtime-versions:
+                nodejs: 12.x
             pre_build:
               commands:
                 - aws s3 rm s3://$DEST_BUCKET --recursive
@@ -360,7 +368,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/ubuntu-base:14.04
+        Image: aws/codebuild/standard:4.0
         EnvironmentVariables:
           - Name: DEST_BUCKET
             Value:

--- a/deploy/cloudformation/static-host.yml
+++ b/deploy/cloudformation/static-host.yml
@@ -222,7 +222,7 @@ Resources:
       Description: Basic rewrite rule to send directory requests to appropriate locations in the SPA
       Handler: index.handler
       Role: !GetAtt LambdaEdgeBasicExecutionRole.Arn
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
 
   DefaultDirectoryIndexLambdaV1:
     Type: AWS::Lambda::Version

--- a/deploy/cloudformation/static-host.yml
+++ b/deploy/cloudformation/static-host.yml
@@ -222,7 +222,7 @@ Resources:
       Description: Basic rewrite rule to send directory requests to appropriate locations in the SPA
       Handler: index.handler
       Role: !GetAtt LambdaEdgeBasicExecutionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
 
   DefaultDirectoryIndexLambdaV1:
     Type: AWS::Lambda::Version


### PR DESCRIPTION
The build and node runtimes are outdated and causing failures in the build process. The updates should resolve build and deploy issues and ensure an up-to-date and more secure build and deployment process.

Closes: ESU-1481